### PR TITLE
[FE] 메인 검색 화면 디자인 변경

### DIFF
--- a/FE/src/App.js
+++ b/FE/src/App.js
@@ -10,8 +10,7 @@ function App() {
     <>
       <BrowserRouter>
         <Switch>
-
-          <Route exact path='/' component={Pages.MainPage} />
+          <Route exact path='/' component={Pages.HomePage} />
           <Route
             exact
             path='/searchShared'

--- a/FE/src/layouts/Home/SearchSection.js
+++ b/FE/src/layouts/Home/SearchSection.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import styled from 'styled-components';
+import SearchBar from '@/components/searchShared/searchBar';
+import Note from '@/components/searchShared/note';
+
+const Wrapper = styled.div`
+  margin: 150px auto;
+  width: 100%;
+  height: 100%;
+  background: #fffaf6;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+const Result = styled.div`
+  height: 620px;
+  width: 85%;
+  margin: 0 auto;
+  overflow: hidden;
+  padding: 20px 30px;
+  display: grid;
+  grid-auto-flow: row;
+  justify-content: center;
+  align-content: start;
+  place-items: center;
+  grid-template-rows: 180px;
+  grid-auto-columns: 350px;
+  grid-template-columns: repeat(auto-fill, minmax(auto, 350px));
+`;
+
+const MoreBtn = styled.button`
+  all: unset;
+  cursor: pointer;
+  margin: 10px auto;
+  text-align: center;
+  border: 2px solid #aa856a;
+  border-radius: 25px;
+  background: #ffffff;
+  color: #aa856a;
+  width: 150px;
+  height: 40px;
+  font-size: 15px;
+  font-weight: bold;
+  &:hover,
+  &:active {
+    background: #aa856a;
+    color: #ffffff;
+  }
+`;
+
+const Line = styled.div`
+  margin: 0 auto;
+  width: 80%;
+  border-bottom: 2px solid #aa856a;
+`;
+
+const SearchSection = ({filteredNotes}) => {
+  const filtered = filteredNotes.map((note) => (
+    <Note key={note.id} note={note} />
+  ));
+
+  const onViewMore = () => {
+    console.log(true);
+  };
+  return (
+    <Wrapper>
+      <SearchBar />
+      <Line />
+      <Result>{filtered}</Result>
+      <Line />
+      <MoreBtn onClick={onViewMore}>View All</MoreBtn>
+    </Wrapper>
+  );
+};
+
+export default SearchSection;

--- a/FE/src/pages/Home/HomePresenter.js
+++ b/FE/src/pages/Home/HomePresenter.js
@@ -3,7 +3,9 @@ import styled from 'styled-components';
 import Footer from '@/components/comman/Footer';
 import SectionOne from '@/layouts/Home/SectionOne';
 import GifSection from '@/layouts/Home/GifSection';
-import SectionSearch from '../../layouts/Home/SectionSearch';
+import notes from '@/data/notes';
+
+import SearchSection from '@/layouts/Home/SearchSection';
 
 const Container = styled.div`
   background: #fffaf6;
@@ -17,7 +19,7 @@ const HomePresenter = () => (
   <>
     <Container>
       <SectionOne />
-      <SectionSearch />
+      <SearchSection filteredNotes={notes} />
       <GifSection />
     </Container>
     <Footer />


### PR DESCRIPTION
## 작업내용
- 메인 두번째 화면(검색) 디자인 변경
- 제한적 검색 결과 제공(3줄)
- 전체 검색 결과 화면으로 넘어가는 view all 버튼(기능 미구현)

## 스크린샷 (FE)
![image](https://user-images.githubusercontent.com/40769926/122641151-5e960680-d13e-11eb-9019-27461ede75b4.png)


## 관련 이슈
- close #86